### PR TITLE
Add registration, contacts, and encrypted messaging APIs

### DIFF
--- a/server/messageStore.js
+++ b/server/messageStore.js
@@ -1,0 +1,47 @@
+const crypto = require('crypto');
+
+const SECRET = process.env.MESSAGE_SECRET;
+if (!SECRET) {
+  console.error('MESSAGE_SECRET environment variable not set');
+  process.exit(1);
+}
+
+const KEY = crypto.createHash('sha256').update(SECRET).digest();
+
+function encrypt(text) {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv('aes-256-ctr', KEY, iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+function decrypt(data) {
+  const [ivHex, encryptedHex] = data.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const encrypted = Buffer.from(encryptedHex, 'hex');
+  const decipher = crypto.createDecipheriv('aes-256-ctr', KEY, iv);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+const messages = [];
+
+function storeMessage(fromId, toId, content) {
+  if (!fromId || !toId || !content) {
+    throw new Error('Invalid message');
+  }
+  const encrypted = encrypt(content);
+  messages.push({ fromId, toId, content: encrypted });
+}
+
+function getMessagesFor(userId) {
+  return messages
+    .filter(m => m.toId === userId)
+    .map(m => ({ fromId: m.fromId, content: decrypt(m.content) }));
+}
+
+module.exports = {
+  storeMessage,
+  getMessagesFor,
+};
+

--- a/server/server.js
+++ b/server/server.js
@@ -1,12 +1,10 @@
 const express = require('express');
-const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const { registerUser, verifyUser, findById, addContact } = require('./userStore');
+const { storeMessage, getMessagesFor } = require('./messageStore');
 
 const app = express();
 app.use(express.json());
-
-const users = [];
-const messages = [];
 
 const JWT_SECRET = process.env.JWT_SECRET;
 if (!JWT_SECRET) {
@@ -14,49 +12,81 @@ if (!JWT_SECRET) {
   process.exit(1);
 }
 
-app.post('/signup', async (req, res) => {
-  const { username, password } = req.body;
-  if (!username || !password) {
-    return res.status(400).json({ error: 'Username and password required' });
-  }
-  if (users.find(u => u.username === username)) {
-    return res.status(409).json({ error: 'User already exists' });
-  }
-  const hashed = await bcrypt.hash(password, 10);
-  users.push({ username, password: hashed });
-  res.status(201).json({ message: 'User created' });
-});
-
-app.post('/login', async (req, res) => {
-  const { username, password } = req.body;
-  const user = users.find(u => u.username === username);
-  if (!user) {
-    return res.status(401).json({ error: 'Invalid credentials' });
-  }
-  const valid = await bcrypt.compare(password, user.password);
-  if (!valid) {
-    return res.status(401).json({ error: 'Invalid credentials' });
-  }
-  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
-  res.json({ token });
-});
-
-app.post('/message', (req, res) => {
+function authMiddleware(req, res, next) {
   const auth = req.headers.authorization;
   if (!auth || !auth.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Authorization required' });
   }
   try {
-    const { username } = jwt.verify(auth.slice(7), JWT_SECRET);
-    const { to, content } = req.body;
-    if (!to || !content) {
-      return res.status(400).json({ error: 'Recipient and content required' });
+    const { id } = jwt.verify(auth.slice(7), JWT_SECRET);
+    const user = findById(id);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid token' });
     }
-    messages.push({ from: username, to, content });
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+app.post('/signup', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const user = await registerUser(username, password);
+    res.status(201).json(user);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const user = await verifyUser(username, password);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ id: user.id }, JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+app.post('/contacts/:id', authMiddleware, (req, res) => {
+  const contactId = parseInt(req.params.id, 10);
+  if (Number.isNaN(contactId)) {
+    return res.status(400).json({ error: 'Invalid contact id' });
+  }
+  try {
+    const contacts = addContact(req.user.id, contactId);
+    res.json({ contacts });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post('/messages', authMiddleware, (req, res) => {
+  const { toId, content } = req.body;
+  const to = parseInt(toId, 10);
+  if (Number.isNaN(to) || !content) {
+    return res.status(400).json({ error: 'Recipient and content required' });
+  }
+  if (!findById(to)) {
+    return res.status(404).json({ error: 'Recipient not found' });
+  }
+  try {
+    storeMessage(req.user.id, to, content);
     res.json({ message: 'Message sent' });
   } catch (err) {
-    res.status(401).json({ error: 'Invalid token' });
+    res.status(400).json({ error: err.message });
   }
+});
+
+app.get('/messages', authMiddleware, (req, res) => {
+  const msgs = getMessagesFor(req.user.id);
+  res.json({ messages: msgs });
 });
 
 const PORT = process.env.PORT || 3000;

--- a/server/userStore.js
+++ b/server/userStore.js
@@ -1,0 +1,53 @@
+const bcrypt = require('bcryptjs');
+
+const users = [];
+let nextId = 1;
+
+async function registerUser(username, password) {
+  if (!username || !password) {
+    throw new Error('Username and password required');
+  }
+  if (users.find(u => u.username === username)) {
+    throw new Error('User already exists');
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  const user = { id: nextId++, username, password: hashed, contacts: [] };
+  users.push(user);
+  return { id: user.id, username: user.username };
+}
+
+async function verifyUser(username, password) {
+  const user = users.find(u => u.username === username);
+  if (!user) {
+    return null;
+  }
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) {
+    return null;
+  }
+  return user;
+}
+
+function findById(id) {
+  return users.find(u => u.id === id);
+}
+
+function addContact(userId, contactId) {
+  const user = findById(userId);
+  const contact = findById(contactId);
+  if (!user || !contact) {
+    throw new Error('User or contact not found');
+  }
+  if (!user.contacts.includes(contactId)) {
+    user.contacts.push(contactId);
+  }
+  return user.contacts;
+}
+
+module.exports = {
+  registerUser,
+  verifyUser,
+  findById,
+  addContact,
+};
+


### PR DESCRIPTION
## Summary
- modularize user management with ID assignment and contact lists
- add encrypted message storage module
- expose routes for adding contacts and sending/receiving messages with validation

## Testing
- `npm test`
- `JWT_SECRET=test MESSAGE_SECRET=test node server.js` (startup)


------
https://chatgpt.com/codex/tasks/task_e_689ca03990608330b0887c77d0b752c6