### PR TITLE
Add dotenv-based config and Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Hosts encrypted messenger platform on a .onion link, simple user signup and assi
 git clone https://github.com/<user>/OnionMessenger.git
 cd OnionMessenger/server
 npm install
+cp .env.example .env   # on Windows use: copy .env.example .env
 ```
+
+Edit the newly created `.env` file and provide your own secret values.
 
 ## Running the service
 
@@ -44,7 +47,15 @@ npm install
 2. Launch the application from the `server/` directory:
 
 ```bash
-JWT_SECRET=your-secret npm start
+npm start
+```
+
+Environment variables from `.env` are loaded automatically. If you prefer to set them manually on Windows PowerShell use:
+
+```powershell
+$env:JWT_SECRET="your-secret"
+$env:MESSAGE_SECRET="your-msg-secret"
+npm start
 ```
 
 3. Access the service via the generated `.onion` address using the Tor Browser.
@@ -53,5 +64,6 @@ JWT_SECRET=your-secret npm start
 ## Environment variables
 
 - `JWT_SECRET`: Secret key used to sign authentication tokens. **Required**.
+- `MESSAGE_SECRET`: Key used to encrypt stored messages. **Required**.
 - `PORT`: Port for the HTTP server. Defaults to `3000`.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env and replace with your own secrets
+JWT_SECRET=change-me
+MESSAGE_SECRET=change-me
+#PORT=3000

--- a/server/messageStore.js
+++ b/server/messageStore.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const crypto = require('crypto');
 
 const SECRET = process.env.MESSAGE_SECRET;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0"
       },
@@ -2186,6 +2187,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const jwt = require('jsonwebtoken');
 const { registerUser, verifyUser, findById, addContact } = require('./userStore');


### PR DESCRIPTION
## Summary
- Load environment variables from `.env` using `dotenv`
- Document Windows-friendly setup and env configuration
- Provide example `.env` file for easier configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9b749afc833093a3c587a2c38915